### PR TITLE
AppData: fix bugtracker URL

### DIFF
--- a/data/com.github.tenderowl.norka.appdata.xml.in
+++ b/data/com.github.tenderowl.norka.appdata.xml.in
@@ -20,7 +20,7 @@
   <launchable type="desktop-id">com.github.tenderowl.norka.desktop</launchable>
   <developer_name>Andrey Maksimov</developer_name>
   <url type="homepage">https://tenderowl.com/norka</url>
-  <url type="bugtracker">https://github.com/github/tenderowl/norka/issues</url>
+  <url type="bugtracker">https://github.com/tenderowl/norka/issues</url>
 
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
Congrats on the release!

Also, I noticed that the version in the AppData is `0.1.3`, but the Git tag and the version number in Meson are both `0.1.0`?