### PR TITLE
Appdata related changes

### DIFF
--- a/data/com.github.tenderowl.norka.appdata.xml.in
+++ b/data/com.github.tenderowl.norka.appdata.xml.in
@@ -24,7 +24,7 @@
 
     <launchable type="desktop-id">com.github.tenderowl.norka.desktop</launchable>
     <translation type="gettext">com.github.tenderowl.norka</translation>
-    <developer_name translatable="no">Tender Owl</developer_name>
+    <developer_name translate="no">Tender Owl</developer_name>
     <url type="homepage">https://norka.app/</url>
     <url type="bugtracker">https://github.com/tenderowl/norka/issues</url>
     <url type="vcs-browser">https://github.com/tenderowl/norka</url>
@@ -45,7 +45,7 @@
 
     <releases>
         <release date="2023-06-06" version="1.1.0">
-            <description translatable="no">
+            <description translate="no">
                 <p>Hooray 🎉️! A new version of the Norka text editor has been released, in which you will find many
                     improvements and new features. The interface has become more modern and convenient, the processing
                     of command line arguments has been fixed and improved, and a full-fledged autosave has finally
@@ -56,13 +56,13 @@
             </description>
         </release>
         <release date="2022-03-08" version="1.0.1">
-            <description translatable="no">
+            <description translate="no">
                 <p>Fix issue when doesn't start Norka at the first launch.</p>
                 <p>Updated Russian translation.</p>
             </description>
         </release>
         <release date="2022-02-03" version="1.0.0">
-            <description translatable="no">
+            <description translate="no">
                 <p>New</p>
                 <ul>
                     <li>You can create folders to structure your notes</li>
@@ -81,12 +81,12 @@
             </description>
         </release>
         <release date="2021-10-13" version="0.8.2">
-            <description translatable="no">
+            <description translate="no">
                 <p>Bugfixes and UI improvements.</p>
             </description>
         </release>
         <release date="2021-09-18" version="0.8.0">
-            <description translatable="no">
+            <description translate="no">
                 <p>Backup, export to Docx and PDF and more.</p>
                 <ul>
                     <li>Backup option available in the main menu</li>
@@ -99,7 +99,7 @@
             </description>
         </release>
         <release date="2021-04-08" version="0.7.2">
-            <description translatable="no">
+            <description translate="no">
                 <p>New app page and</p>
                 <ul>
                     <li>New app screenshots</li>
@@ -108,7 +108,7 @@
             </description>
         </release>
         <release date="2021-02-13" version="0.7.0">
-            <description translatable="no">
+            <description translate="no">
                 <p>Improvements</p>
                 <ul>
                     <li>Dark mode</li>
@@ -117,7 +117,7 @@
             </description>
         </release>
         <release date="2021-01-20" version="0.6.3">
-            <description translatable="no">
+            <description translate="no">
                 <p>Improvements</p>
                 <ul>
                     <li>Fix extra dot for exported md files.</li>
@@ -126,7 +126,7 @@
             </description>
         </release>
         <release date="2020-10-07" version="0.6.2">
-            <description translatable="no">
+            <description translate="no">
                 <p>Improvements</p>
                 <ul>
                     <li>Editor width limited to 800 px for the best experience</li>
@@ -138,24 +138,24 @@
             </description>
         </release>
         <release date="2020-08-31" version="0.5.1">
-            <description translatable="no">
+            <description translate="no">
                 <p>Update app translation.</p>
             </description>
         </release>
         <release date="2020-08-29" version="0.5.0">
-            <description translatable="no">
+            <description translate="no">
                 <p>A new fancy way to search through your documents is available. And Norka is fully localizable now.
                     You are welcome :)
                 </p>
             </description>
         </release>
         <release date="2020-08-13" version="0.4.7">
-            <description translatable="no">
+            <description translate="no">
                 <p>Update metadata.</p>
             </description>
         </release>
         <release date="2020-08-12" version="0.4.6">
-            <description translatable="no">
+            <description translate="no">
                 <p>Improvements</p>
                 <ul>
                     <li>Set the minimum size of the Preferences dialog</li>
@@ -164,7 +164,7 @@
             </description>
         </release>
         <release date="2020-07-21" version="0.4.3">
-            <description translatable="no">
+            <description translate="no">
                 <p>Some fixes:</p>
                 <ul>
                     <li>Properly toggle welcome screen and show archived</li>
@@ -174,7 +174,7 @@
             </description>
         </release>
         <release date="2020-07-17" version="0.4.2">
-            <description translatable="no">
+            <description translate="no">
                 <p>Yet another update: small but valuable.</p>
                 <p>What it brings to us:</p>
                 <ul>
@@ -189,7 +189,7 @@
             </description>
         </release>
         <release date="2020-07-16" version="0.3.0">
-            <description translatable="no">
+            <description translate="no">
                 <p>TenderOwl thinks a living project is better than enormous updates yet we created a new little one!
                 </p>
                 <p>This release brings a new feature - export to Medium. All you need is open preferences and put the
@@ -203,7 +203,7 @@
             </description>
         </release>
         <release date="2020-06-28" version="0.2.0">
-            <description translatable="no">
+            <description translate="no">
                 <p>Norka grows up and learn new tricks like import files to Norka's documents!
                     You could use any methods you like: drag-n-drop, keyboard shortcut (Ctrl+O) or Headerbar button. And
                     from command line of course!
@@ -217,7 +217,7 @@
             </description>
         </release>
         <release date="2020-06-12" version="0.1.4">
-            <description translatable="no">
+            <description translate="no">
                 <p>
                     Search and Shortcuts.
                     Now you can use Text Search via keyboard shortcuts:
@@ -230,7 +230,7 @@
             </description>
         </release>
         <release date="2020-06-07" version="0.1.0">
-            <description translatable="no">
+            <description translate="no">
                 <p>Initial release of Norka. Young yet ready to provide you with editing functions and Markdown
                     formatter, even export but who needs it.
                 </p>

--- a/data/com.github.tenderowl.norka.appdata.xml.in
+++ b/data/com.github.tenderowl.norka.appdata.xml.in
@@ -25,6 +25,9 @@
     <launchable type="desktop-id">com.github.tenderowl.norka.desktop</launchable>
     <translation type="gettext">com.github.tenderowl.norka</translation>
     <developer_name translate="no">Tender Owl</developer_name>
+    <developer id="io.github.tenderowl">
+        <name translate="no">Tender Owl</name>
+    </developer>
     <url type="homepage">https://norka.app/</url>
     <url type="bugtracker">https://github.com/tenderowl/norka/issues</url>
     <url type="vcs-browser">https://github.com/tenderowl/norka</url>


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer